### PR TITLE
Fix full stop glitch

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
          <center>
 		 <a id="ad1link" target="_blank"><img id="ad1" height="100" width="400"></img></a>
 	      <br>
-	      Get an ad by <a href="donate.html" style="color:darkgray">donating.</a>
+	      Get an ad by <a href="donate.html" style="color:darkgray">donating</a>.
 	      <br>
         <br>
          <div class="text-block" style="display:inline-block;">


### PR DESCRIPTION
Currently in the "Get an ad by donating." bit of text, the ``.`` is part of the ``donating`` link when it should just be normal text, This PR fixes that.